### PR TITLE
Makes sure selved line is chomp-ed before splitting into an array

### DIFF
--- a/SelvedWrapper/return_all_input.rb
+++ b/SelvedWrapper/return_all_input.rb
@@ -33,11 +33,11 @@ class ReturnAllInput
   end
 
   def update_hash(file)
-    lines = IO.readlines(file, chomp: true)
+    lines = IO.readlines(file)
     @hash.each do |key, value|
       hash_order_key = value.split('|')[0]
       lines.each do |line|
-        line_array = line.split('|')
+        line_array = line.chomp.split('|')
         line_array[0] == hash_order_key && @hash[key] << "|#{line_array.slice(-1)}" && break
       end
     end


### PR DESCRIPTION
For some reason the `chomp:true` attribute for `IO.readlines` did not seem to be working as expected and newline chars were being introduced into the selved lines, so when trying to grab the last pipe field (the selved data) using `Array.slice(-1)` it was grabbing a newline instead.